### PR TITLE
Check in shared travis scripts

### DIFF
--- a/ci/check-worktree-is-clean
+++ b/ci/check-worktree-is-clean
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+# ensure the index is up to date, in CI we were seeing some cases
+# where git diff-files would show the entire tree was unmerged
+# and this addresses that.
+git update-index -q --refresh
+
+if ! git diff-files --quiet; then
+    >&2 echo "error: working tree is not clean, aborting!"
+    git status
+    exit 1
+fi

--- a/ci/ensure-dependencies
+++ b/ci/ensure-dependencies
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+# Run our target to dep ensure and yarn install everything
+make ensure
+
+# Ensure the working tree is clean (make ensure may have updated lock files)
+$(go env GOPATH)/src/github.com/pulumi/scripts/ci/check-worktree-is-clean.sh
+
+# Set stdout back to blocking to avoid problems writing large outputs.
+# https://github.com/pulumi/pulumi-ppc/issues/176
+python -c 'import fcntl, os, sys; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); print("stdout was " + ("nonblocking" if flags & os.O_NONBLOCK else "blocking")); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)'

--- a/ci/install-common-toolchain.sh
+++ b/ci/install-common-toolchain.sh
@@ -1,0 +1,92 @@
+nvm install ${NODE_VERSION-v8.11.1}
+
+# Travis sources this script, so we can export variables into the
+# outer shell, so we don't want to set options like nounset because
+# they would be set in the outer shell as well, so do as much logic as
+# we can in a subshell.
+(
+    set -o nounset -o errexit -o pipefail
+    [ -e "$(go env GOPATH)/bin" ] || mkdir -p "$(go env GOPATH)/bin"
+
+    YARN_VERSION="1.3.2"
+    DEP_VERSION="0.4.1"
+    GOMETALINTER_VERSION="2.0.3"
+    PIP_VERSION="10.0.0"
+    VIRTUALENV_VERSION="15.2.0"
+    AWSCLI_VERSION="1.14.30"
+    WHEEL_VERSION="0.30.0"
+    TWINE_VERSION="1.9.1"
+
+    OS=""
+    case $(uname) in
+        "Linux") OS="linux";;
+        "Darwin") OS="darwin";;
+        *) echo "error: unknown host os $(uname)" ; exit 1;;
+    esac
+
+    # On Travis, pip is called pip2.7, so alias it, also install jq
+    if [ "${TRAVIS_OS_NAME:-}" = "osx" ]; then
+        sudo ln -s $(which pip2.7) /usr/local/bin/pip
+        brew install jq
+    fi
+
+    echo "installing yarn ${YARN_VERSION}"
+    curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}
+
+    echo "installing dep ${DEP_VERSION}"
+    curl -L -o "$(go env GOPATH)/bin/dep" https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-${OS}-amd64
+    chmod +x "$(go env GOPATH)/bin/dep"
+
+    echo "installing Gometalinter ${GOMETALINTER_VERSION}"
+    curl -L "https://github.com/alecthomas/gometalinter/releases/download/v${GOMETALINTER_VERSION}/gometalinter-v${GOMETALINTER_VERSION}-${OS}-amd64.tar.bz2" | tar -jxv --strip-components=1 -C "$(go env GOPATH)/bin"
+
+    chmod +x "$(go env GOPATH)/bin/gometalinter"
+    chmod +x "$(go env GOPATH)/bin/linters/"*
+
+    # Gometalinter looks for linters on the $PATH, so let's move them out
+    # of the linters folder and into GOBIN (which we know is on the $PATH)
+    mv "$(go env GOPATH)/bin/linters/"* "$(go env GOPATH)/bin/."
+    rm -rf "$(go env GOPATH)/bin/linters/"
+
+    echo "installing gocovmerge"
+
+    # gocovmerge does not publish versioned releases, but it also hasn't been updated in two years, so
+    # getting HEAD is pretty safe.
+    go get -v github.com/wadey/gocovmerge
+
+    echo "upgrading Pip to ${PIP_VERSION}"
+    sudo pip install --upgrade "pip>=${PIP_VERSION}"
+    pip install --user --upgrade "pip>=${PIP_VERSION}"
+
+    echo "installing virtualenv ${VIRTUALENV_VERSION}"
+    sudo pip install "virtualenv==${VIRTUALENV_VERSION}"
+    pip install --user "virtualenv==${VIRTUALENV_VERSION}"
+
+    echo "installing AWS cli ${AWSCLI_VERSION}"
+    pip install --user "awscli==${AWSCLI_VERSION}"
+
+    echo "installing Wheel and Twine, so we can publish Python packages"
+    pip install --user "wheel==${WHEEL_VERSION}" "twine==${TWINE_VERSION}"
+
+    echo "installing pandoc, so we can generate README.rst for Python packages"
+    if [ "${TRAVIS_OS_NAME:-}" = "linux" ]; then
+        sudo apt-get install pandoc
+    else
+        brew install pandoc
+    fi
+)
+
+# If the sub shell failed, bail out now.
+[ "$?" -eq 0 ] || exit 1
+
+# By default some tools are not on the PATH, let's fix that
+
+# On OSX, the user folder that `pip` installs tools to is not on the
+# $PATH by default.
+if [ "${TRAVIS_OS_NAME:-}" = "osx" ]; then
+    export PATH=$PATH:$HOME/Library/Python/2.7/bin
+    export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages
+fi
+
+# Add yarn to the $PATH
+export PATH=$HOME/.yarn/bin:$PATH

--- a/ci/prepare-environment.sh
+++ b/ci/prepare-environment.sh
@@ -1,0 +1,25 @@
+# Travis sources this script, so we can export variables into the
+# outer shell, so we don't want to set options like nounset because
+# they would be set in the outer shell as well, so do as much logic as
+# we can in a subshell.
+
+export PULUMI_SCRIPTS="$(go env GOPATH)/src/github.com/pulumi/scripts"
+
+(
+    set -o nounset -o errexit -o pipefail
+
+    if [ "${TRAVIS_OS_NAME:-}" = "osx" ]; then
+        sudo mkdir /opt/pulumi
+        sudo chown "${USER}" /opt/pulumi
+    fi
+
+    # If we have an NPM token, put it in the .npmrc file, so we can use it:
+    if [ ! -z "${NPM_TOKEN:-}" ]; then
+        echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
+    fi
+
+    # Put static entries for Pulumi backends in /etc/hosts
+    "${PULUMI_SCRIPTS}/ci/pulumi-hosts" | sudo tee -a /etc/hosts
+) || exit 1  # Abort outer script if subshell fails.
+
+export PULUMI_ROOT=/opt/pulumi

--- a/ci/upload-failed-tests
+++ b/ci/upload-failed-tests
@@ -2,6 +2,12 @@
 
 set -o nounset -o errexit -o pipefail
 
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+    echo "Some tests failed, but AWS_ACCESS_KEY was not defined, so we will not upload failure logs."
+    echo "This happens when the tests failed while building a Pull Request job from a fork on Travis."
+    exit 0
+fi
+
 # before tests, source keep-failed-tests.sh
 
 tar czf - -C "${PULUMI_FAILED_TESTS_DIR}" . | aws --region us-west-2 s3 cp - "s3://eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/failed-tests.tar.gz" --acl bucket-owner-full-control


### PR DESCRIPTION
Take `pulumi/pulumi`'s scripts that are used in CI and share them
here. We'll move to a model where travis clones this repository and
then invokes these scripts directly, instead of having each repository
have to clone a bunch of logic around how to install toolchains, what
versions of things to install and the like.