### PR TITLE
Run `apt-get update` before installing pandoc

### DIFF
--- a/ci/install-common-toolchain.sh
+++ b/ci/install-common-toolchain.sh
@@ -70,6 +70,7 @@ nvm install ${NODE_VERSION-v8.11.1}
 
     echo "installing pandoc, so we can generate README.rst for Python packages"
     if [ "${TRAVIS_OS_NAME:-}" = "linux" ]; then
+        sudo apt-get update
         sudo apt-get install pandoc
     else
         brew install pandoc


### PR DESCRIPTION
On some of the travis workers, it looks like the apt-get cache does
not contain pandoc, and so an explicit `apt-get update` is required
before trying to install pandoc.