### PR TITLE
Open source `hack-vendor`

### DIFF
--- a/hack-vendor/cmd/change-constraint/main.go
+++ b/hack-vendor/cmd/change-constraint/main.go
@@ -1,0 +1,120 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+func main() {
+	var name string
+	var revision string
+	var serverPrefix string
+	var gopkgFile string
+
+	flag.StringVar(&name, "name", "", "the name of the project to modify")
+	flag.StringVar(&revision, "revision", "", "the revision of the project to pin to")
+	flag.StringVar(&serverPrefix, "serverPrefix", "http://localhost.pulumi.engineering/", "the url of a git server that exposes $GOPATH")
+	flag.StringVar(&gopkgFile, "file", "Gopkg.toml", "the path to the Gopkg.toml to modify")
+	flag.Parse()
+
+	if name == "" {
+		fmt.Fprintf(os.Stderr, "error: must provide package to modify with -name\n")
+		os.Exit(1)
+	}
+
+	if revision == "" {
+		fmt.Fprintf(os.Stderr, "error: must provide version to use with -version\n")
+		os.Exit(1)
+	}
+
+	if !strings.HasSuffix(serverPrefix, "/") {
+		serverPrefix = serverPrefix + "/"
+	}
+
+	b, err := ioutil.ReadFile(gopkgFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	var gopkg Gopkg
+
+	if err := toml.Unmarshal(b, &gopkg); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	hadExisting := false
+	for idx, override := range gopkg.Override {
+		if override.Name == name {
+			newSource := serverPrefix + override.Name
+
+			if override.Source != "" {
+				newSource = serverPrefix + override.Source
+			}
+
+			gopkg.Override[idx] = Override{
+				Name:     name,
+				Revision: revision,
+				Source:   newSource,
+			}
+
+			hadExisting = true
+			break
+		}
+	}
+
+	if !hadExisting {
+		gopkg.Override = append(gopkg.Override, Override{
+			Name:     name,
+			Revision: revision,
+			Source:   serverPrefix + name,
+		})
+	}
+
+	f, err := os.OpenFile(gopkgFile, os.O_RDWR|os.O_TRUNC, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	err = toml.NewEncoder(f).Encode(gopkg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type Gopkg struct {
+	Required []string   `toml:"required"`
+	Ignored  []string   `toml:"ignored"`
+	Override []Override `toml:"override"`
+}
+
+type Override struct {
+	Name     string `toml:"name"`
+	Version  string `toml:"version,omitempty"`
+	Branch   string `toml:"branch,omitempty"`
+	Revision string `toml:"revision,omitempty"`
+	Source   string `toml:"source,omitempty"`
+}

--- a/hack-vendor/cmd/vendor-git-server/main.go
+++ b/hack-vendor/cmd/vendor-git-server/main.go
@@ -1,0 +1,65 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"net/http/cgi"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	var root string
+	flag.StringVar(&root, "root", "", "root directory to serve from")
+	flag.Parse()
+
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if root == "" {
+		fmt.Fprintf(os.Stderr, "error: must supply path with -root\n")
+		os.Exit(1)
+	}
+
+	handler := &cgi.Handler{
+		Path: gitPath,
+		Root: "",
+		Args: []string{"http-backend"},
+		Env: []string{
+			fmt.Sprintf("GIT_PROJECT_ROOT=%v", root),
+			"GIT_HTTP_EXPORT_ALL=1",
+		},
+	}
+
+	http.HandleFunc("/", func(rw http.ResponseWriter, req *http.Request) {
+		values := req.URL.Query()
+		if values.Get("go-get") == "1" {
+			rw.Write([]byte(fmt.Sprintf("<meta name=\"go-import\" content=\"localhost.pulumi.engineering git http://localhost.pulumi.engineering/%v\">", req.URL.Path)))
+		} else {
+			handler.ServeHTTP(rw, req)
+		}
+	})
+
+	if err := http.ListenAndServe(fmt.Sprintf("localhost:80"), nil); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/hack-vendor/hack-vendor
+++ b/hack-vendor/hack-vendor
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+# Install some tools
+go get github.com/BurntSushi/toml
+go install github.com/pulumi/scripts/hack-vendor/cmd/vendor-git-server
+go install github.com/pulumi/scripts/hack-vendor/cmd/change-constraint
+
+on_exit() {
+    mv Gopkg.toml.orig Gopkg.toml
+    sudo killall vendor-git-server
+}
+
+if [ ! -e Gopkg.toml ]; then
+    "error: run this script from the root of a project you'd like to modify the dependencies of"
+fi
+
+# Back up the existing file (since we are going to modify it)
+cp Gopkg.toml Gopkg.toml.orig
+
+trap on_exit EXIT
+
+for PACKAGE in "$@"; do
+    COMMIT=$(git -C $(go env GOPATH)/src/${PACKAGE} rev-parse HEAD)
+
+    if [ -z "${COMMIT}" ]; then
+        echo "error: could not determine commit for ${PACKAGE}"
+        exit 1
+    fi
+
+    echo "setting ${PACKAGE} to version ${COMMIT}"
+    change-constraint -name "${PACKAGE}" -revision "${COMMIT}"
+done
+
+echo "running vendor-git-server, this requires superuser access to bind to port 80..."
+
+sudo sh -c "$(command -v vendor-git-server) -root $(go env GOPATH)/src &"
+
+echo "server running..."
+
+dep ensure -v


### PR DESCRIPTION
`hack-vendor` is a small script that makes it quick to override a
vendored dependency (managed by `dep`) with a local version. It works
by spinning up a local web server that exposes $GOPATH/src and then
modifies the `Gopkg.toml` file of a project to override the source of
the package you want to modify to point at this local server and does
a restore.

The web-server listens on port 80, due to limitiations with `dep` when
this script was authored. It appears that newer versions would allow
sources to actually have a non standard port, so in the future we may
be able to modify the scripts to just have the web-server listen on
some non standard port, which would prevent the need to sudo.