### PR TITLE
Don't create symlink if it already exists

### DIFF
--- a/ci/install-common-toolchain.sh
+++ b/ci/install-common-toolchain.sh
@@ -25,7 +25,7 @@ nvm install ${NODE_VERSION-v8.11.1}
     esac
 
     # On Travis, pip is called pip2.7, so alias it, also install jq
-    if [ "${TRAVIS_OS_NAME:-}" = "osx" ]; then
+    if [ "${TRAVIS_OS_NAME:-}" = "osx" ] && [ ! -f /usr/local/bin/pip ]; then
         sudo ln -s $(which pip2.7) /usr/local/bin/pip
         brew install jq
     fi

--- a/ci/install-common-toolchain.sh
+++ b/ci/install-common-toolchain.sh
@@ -24,10 +24,13 @@ nvm install ${NODE_VERSION-v8.11.1}
         *) echo "error: unknown host os $(uname)" ; exit 1;;
     esac
 
-    # On Travis, pip is called pip2.7, so alias it, also install jq
-    if [ "${TRAVIS_OS_NAME:-}" = "osx" ] && [ ! -f /usr/local/bin/pip ]; then
-        sudo ln -s $(which pip2.7) /usr/local/bin/pip
+    # Tool installs and workarounds specific to macOS.
+    if [ "${TRAVIS_OS_NAME:-}" = "osx" ]; then
         brew install jq
+        # On Travis, pip is called pip2.7, so alias it.
+        if [ ! -f /usr/local/bin/pip ]; then
+            sudo ln -s $(which pip2.7) /usr/local/bin/pip
+        fi
     fi
 
     echo "installing yarn ${YARN_VERSION}"


### PR DESCRIPTION
We have started seeing failures in `pulumi/pulumi` on macOS with:

```
$ source ./build/travis/install-common-toolchain.sh
Downloading and installing node v6.10.3...
Downloading https://nodejs.org/dist/v6.10.3/node-v6.10.3-darwin-x64.tar.xz...
Computing checksum with shasum -a 256
Checksums matched!
Now using node v6.10.3 (npm v3.10.10)
ln: /usr/local/bin/pip: File exists
```

This seems like a reasonable fix. Since we don't control the Travis environment, perhaps this was a bug that was "fixed" which in-turn broke our workaround.