### PR TITLE
Adopt new node installer scripts

### DIFF
--- a/ci/add-plugin-installer-script.js
+++ b/ci/add-plugin-installer-script.js
@@ -1,0 +1,44 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This program simply reads a package.json from stdin, takes a set of arguments representing
+// package names, and for each one, promotes that package from a peerDependency to a real dependency.
+
+// Read the package.json from stdin.
+let packageJSONText = "";
+const readline = require("readline");
+const stdin = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+});
+stdin.on("line", function(line) {
+    packageJSONText += `${line}\n`;
+});
+stdin.on("close", function() {
+    // All stdin is available. Add our install script.
+    const packageJSON = JSON.parse(packageJSONText);
+
+    if (!packageJSON.scripts) {
+        packageJSON.scripts = {};
+    }
+    var name = packageJSON.name;
+    if (name.lastIndexOf("/") !== -1) {
+        name = name.substring(name.lastIndexOf("/")+1);
+    }
+    packageJSON.scripts["install"] = `node scripts/install-pulumi-plugin.js resource ${name} ${packageJSON.version}`;
+
+    // Now print out the result to stdout.
+    console.log(JSON.stringify(packageJSON, null, 4));
+});

--- a/ci/install-pulumi-plugin.js
+++ b/ci/install-pulumi-plugin.js
@@ -1,0 +1,21 @@
+"use strict";
+var childProcess = require("child_process");
+
+var args = process.argv.slice(2);
+var res = childProcess.spawnSync("pulumi", ["plugin", "install"].concat(args), {
+    stdio: ["ignore", "inherit", "inherit"]
+});
+
+if (res.error && res.error.code === "ENOENT") {
+    console.error("\nThere was an issue installing the resource provider plugin. " +
+            "It looks like `pulumi` is not installed on your system. " +
+            "Please visit https://pulumi.io/ to get Pulumi.\n" +
+            "You may try to manually installing the plugin by running " +
+            "`pulumi plugin install " + args.join(" ") + "`");
+} else if (res.error || res.status !== 0) {
+    console.error("\nThere was an issue installing the resource provider plugin. " +
+            "You may try to manually installing the plugin by running " +
+            "`pulumi plugin install " + args.join(" ") + "`");
+}
+
+process.exit(0);

--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -1,0 +1,54 @@
+#!/bin/bash
+# publish-tfgen-package publishes the packages for a "terraform based" resource provider
+# (i.e. one produced by using tfgen and tfbridge). It has some assumptions about the common
+# layout we use for our terraform based resource providers.
+#
+# usage publish-tfgen-package <path-to-repository-root>
+set -o nounset -o errexit -o pipefail
+if [ "$#" -ne 1 ]; then
+    >&2 echo "usage: $0 <path-to-repository-root>"
+    exit 1
+fi
+
+SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+SOURCE_ROOT="$1"
+
+if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
+    # Publish the NPM package.
+    echo "Publishing NPM package to NPMjs.com:"
+
+    # First, add an install script to our package.json
+    mkdir -p "${SOURCE_ROOT}/sdk/nodejs/bin/scripts"
+    cp "${SCRIPT_ROOT}/install-pulumi-plugin.js" \
+       "${SOURCE_ROOT}/sdk/nodejs/bin/scripts"
+    node "${SCRIPT_ROOT}/add-plugin-installer-script.js" < \
+        "${SOURCE_ROOT}/sdk/nodejs/bin/package.json" > \
+        "${SOURCE_ROOT}/sdk/nodejs/bin/package.json.publish"
+    pushd "${SOURCE_ROOT}/sdk/nodejs/bin"
+    mv package.json package.json.dev
+    mv package.json.publish package.json
+
+    NPM_TAG="dev"
+
+    # If the package doesn't have a pre-release tag, use the tag of latest instead of
+    # dev. NPM uses this tag as the default version to add, so we want it to mean
+    # the newest released version.
+    if [[ $(jq -r .version < package.json) != *-* ]]; then
+        NPM_TAG="latest"
+    fi
+
+    # Now, perform the publish.
+    npm publish -tag "${NPM_TAG}"
+    npm info 2>/dev/null
+
+    # And finally restore the original package.json.
+    mv package.json package.json.publish
+    mv package.json.dev package.json
+    popd
+
+    # Next, publish the PyPI package.
+    echo "Publishing Pip package to pulumi.com:"
+    twine upload \
+        -u pulumi -p "${PYPI_PASSWORD}" \
+        "${SOURCE_ROOT}/sdk/python/bin/dist/*.tar.gz"
+fi


### PR DESCRIPTION
This change extracts the shared logic we have duplicated in every
terraform based provider repository into a common location.

In addition, it augments the publishing scripts to support
pulumi/pulumi#2155.

Previously, the poorly named `promote.js` would rewrite the
`package.json` of a package before we were going to publish it. It
would add an `install` script to the `scripts` section of package.json
which called `pulumi plugin install resource <name> <version>` so that
when packages were restored, the plugin would be installed.

However, when installing on a machine where `pulumi` was not present,
this script would fail and cause the entire `npm install` or `yarn
install` to fail because `pulumi` could not be run.

Now, instead of invoking pulumi directly, we invoke a script which
ships with the package (and who's source lives here and is injected
into the package as we are preparing it to publish) that tries to
shell out to `pulumi` and handles the errors in a nicer manner.

This allows plugin install to work even if `pulumi` is not on the
machine or not on the path.