### PR TITLE
Add a script for testing "at HEAD"

### DIFF
--- a/ci/run-at-head
+++ b/ci/run-at-head
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+ALL_PACKAGES=(
+    "@pulumi/aws"
+    "@pulumi/aws-infra"
+    "@pulumi/aws-serverless"
+    "@pulumi/azure"
+    "@pulumi/azure-serverless"
+    "@pulumi/cloud"
+    "@pulumi/cloud-aws"
+    "@pulumi/cloud-azure"
+    "@pulumi/docker"
+    "@pulumi/eks"
+    "@pulumi/gcp"
+    "@pulumi/kubernetes"
+    "@pulumi/openstack"
+    "@pulumi/pulumi"
+    "@pulumi/random"
+    "@pulumi/terraform-template"
+    "@pulumi/vsphere"
+)
+
+echo "Installing latest Pulumi CLI"
+curl -sSL https://get.pulumi.com | bash -s -- --version "$(curl -sSL "http://registry.npmjs.org/-/package/@pulumi/pulumi/dist-tags" | jq -r .dev)"
+
+OVERRIDES="";
+
+for PACKAGE in "${ALL_PACKAGES[@]}"; do
+    echo -n "Determining latest version of ${PACKAGE}..."
+    DEV_VERSION="$(curl -sSL "http://registry.npmjs.org/-/package/${PACKAGE}/dist-tags" | jq -r .dev)"
+
+    if [ "${DEV_VERSION}" = "null" ]; then
+        echo "could not compute latest version of ${PACKAGE}, is it missing a dev tag in NPM?"
+    else
+        echo "${DEV_VERSION}"
+        OVERRIDES="${OVERRIDES}:${PACKAGE}=${DEV_VERSION}"        
+    fi
+done
+
+export PULUMI_TEST_NODE_OVERRIDES="${OVERRIDES:1}"
+make "travis_${TRAVIS_EVENT_TYPE}"


### PR DESCRIPTION
The intention of this new script is to allow us to run our node tests
"at HEAD". When run, this script does a few things:

1. For every `@pulumi` package, figure out the latest version, by
   looking at what the `dev` tag points at.

2. Install the latest dev build of the CLI (i.e. the one that matches
   the "dev" tag of @pulumi/pulumi).

3. Set an environment variaible that has information about the latest
   versions of all the packages.

4. Call `make travis_${TRAVIS_EVENT_TYPE}` like a normal Travis build
   would.

The integration tests in each repository will use the environment
variable that we've set to pass information about the latest versions
to the integration test framework, to ensure we use the newest
versions.