### PR TITLE
Omit empty constraints in change-constraint

### DIFF
--- a/hack-vendor/cmd/change-constraint/main.go
+++ b/hack-vendor/cmd/change-constraint/main.go
@@ -97,6 +97,9 @@ func main() {
 			break
 		}
 	}
+	if len(gopkg.Constraint) == 0 {
+		gopkg.Constraint = nil
+	}
 
 	f, err := os.OpenFile(gopkgFile, os.O_RDWR|os.O_TRUNC, 0644)
 	if err != nil {


### PR DESCRIPTION
Just what it says on the tin. dep fails to parse the TOML otherwise.