### PR TITLE
Target exact versions in `govendor-override`

### DIFF
--- a/govendor-override/main.go
+++ b/govendor-override/main.go
@@ -281,7 +281,7 @@ func main() {
 				if v.Version == "master" {
 					fmt.Printf("  branch = \"%s\"\n", v.Version)
 				} else {
-					fmt.Printf("  version = \"%s\"\n", v.Version)
+					fmt.Printf("  version = \"=%s\"\n", v.Version)
 				}
 			} else {
 				fmt.Printf("  revision = \"%s\"\n", v.Revision)


### PR DESCRIPTION
`govendor-override` is designed to _exactly_ match the dependency versions specified by an upstream Terraform provider when resolving dependencies for a Pulumi resource provider based upon it.

Unfortunately, we misinterpreted the semantics of `dep` when a semantic version is specified, and as such were pinning to a major version, but not an exact version. For a long time, semantic versioning worked as designed and we didn't see an breakage with this, but terraform-providers/terraform-provider-aws#6806 saw a regression in an upstream library meaning pinning to the exact version of the AWS SDK specified by upstream is required.

According to the dep docs:

> When you specify a version without an operator, dep automatically uses the ^ operator by default. dep ensure will interpret the given version as the min-boundary of a range, for example:
> - 1.2.3 becomes the range >=1.2.3, <2.0.0
> - 0.2.3 becomes the range >=0.2.3, <0.3.0
> - 0.0.3 becomes the range >=0.0.3, <0.1.0

Further, to specify an exact version:

> To pin a version of direct dependency in manifest, prefix the version with `=`. For example:
> ```
> [[constraint]]
>   name = "github.com/pkg/errors"
>   version = "=0.8.0"
> ```

This commit switches govendor-override to _always_ pin exact versions rather than version ranges, in line with the aim of the tool.

I have confirmed that running with this change in the AWS repo (where the problem was observed) does lock to the correct version of the AWS SDK following solving with the newly-generated constraints, whereas before it locked to the latest AWS SDK.