### PR TITLE
Add policy checks for packages before publishing

### DIFF
--- a/ci/check-package-dependencies
+++ b/ci/check-package-dependencies
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+# usage: check-package-dependencies <path-to-package-json-file>
+if [ "$#" -ne 1 ]; then
+    >&2 echo "usage: $0 <path-to-package-json-file>"
+    exit 1
+fi
+
+PACKAGE_JSON_PATH=$1
+
+if [ ! -e "${PACKAGE_JSON_PATH}" ]; then
+    >&2 echo "error: '${PACKAGE_JSON_PATH}' not found"
+    exit 1
+fi 
+
+# For stable versions of our packages, we run some additional checks to enforce
+# policy before we publish
+if [[ $(jq -r .version < "${PACKAGE_JSON_PATH}") != *-* ]]; then
+    
+    # We don't want to have stable packages depend on unstable packages, so if any dependency
+    # looks like a pre-release or is using the "dev" tag, block it.
+    if jq -e '.dependencies | to_entries | map(.value | test("-") or test("dev")) | any' < "${PACKAGE_JSON_PATH}" >/dev/null; then
+        >&2 echo "error: one or more dependencies is a pre-release version or dev tag"
+        exit 1
+    fi
+fi
+
+exit 0

--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -13,6 +13,12 @@ fi
 SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 SOURCE_ROOT="$1"
 
+# Before we publish, we run some validation checks over the package
+if ! "${SCRIPT_ROOT}"/check-package-dependencies "${SOURCE_ROOT}/sdk/nodejs/bin/package.json"; then
+    >&2 echo "checking package dependencies failed, refusing to publish"
+    exit 1
+fi
+
 if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     # Publish the NPM package.
     echo "Publishing NPM package to NPMjs.com:"


### PR DESCRIPTION
We want to ensure that when we publish a package, none of the
dependencies are pre-release dependencies (which we, for better or
worse, end up using often during cross cutting development across our
many repositories).

This change adds a new script, `check-package-dependencies` that will
run validation logic against the package.json we are about to publish
and use its exit code to communicate if the package should be
published or not.

Our shared publishing script uses this a pre-check before actually
doing the publish.