### PR TITLE
Make gomod-override work for terraform-provider-aws v1.57.0

### DIFF
--- a/gomod-override/main.go
+++ b/gomod-override/main.go
@@ -224,7 +224,8 @@ func resolveAbbreviatedSHA(importPath, revision string) (string, error) {
 
 	output, err := goGetCmd.CombinedOutput()
 	if err != nil {
-		if !strings.Contains(string(output), fmt.Sprintf("no Go files in %s", tempGoPath)) {
+		if !strings.Contains(string(output), fmt.Sprintf("no Go files in %s", tempGoPath)) &&
+			!strings.Contains(string(output), fmt.Sprintf("build constraints exclude all Go files")) {
 			return "", fmt.Errorf("cannot go get %s:\n%s\n", importPath, string(output))
 		}
 	}

--- a/gomod-override/main.go
+++ b/gomod-override/main.go
@@ -213,13 +213,17 @@ func fetchGoModData(sm gps.SourceManager, constraint gopkgConstraint) ([]byte, e
 }
 
 func resolveAbbreviatedSHA(importPath, revision string) (string, error) {
-	tempGoPath, err := ioutil.TempDir("", "gomod-override")
-	if err != nil {
-		return "", err
+	tempGoPath := os.Getenv("GOMOD_OVERRIDE_GOPATH")
+
+	if tempGoPath == "" {
+		tempGoPath, err := ioutil.TempDir("", "gomod-override")
+		if err != nil {
+			return "", err
+		}
+		defer func() {
+			_ = os.RemoveAll(tempGoPath)
+		}()
 	}
-	defer func() {
-		_ = os.RemoveAll(tempGoPath)
-	}()
 
 	log.Printf("Running go get -u -d %s in temporary GOPATH: %s", importPath, tempGoPath)
 	goGetCmd := exec.Command("go", "get", "-u", "-d", importPath)

--- a/gomod-override/testdata/Gopkg-aws-1.57.0.template.toml
+++ b/gomod-override/testdata/Gopkg-aws-1.57.0.template.toml
@@ -1,0 +1,15 @@
+[[constraint]]
+  branch = "master"
+  name = "github.com/pulumi/pulumi"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/pulumi/pulumi-terraform"
+
+[[constraint]]
+  branch = "pulumi-master"
+  name = "github.com/terraform-providers/terraform-provider-aws"
+  source = "github.com/pulumi/terraform-provider-aws"
+
+  [constraint.metadata]
+    gomod-override = true


### PR DESCRIPTION
Versions like `0.11.1-beta1` have a prerelease tag, but not one of the form `date-SHA` as used by modules to specify exact revisions. If we detect this, we should use the whole version string instead of attempting to extract a SHA.