### PR TITLE
Allow opting into insecure downloads via go get if absolutely necessary

### DIFF
--- a/gomod-override/dependency.go
+++ b/gomod-override/dependency.go
@@ -77,8 +77,13 @@ func (dep dependency) resolveAbbreviatedSHA(revision string) (string, error) {
 		}()
 	}
 
-	log.Printf("Running go get -u -d %s in temporary GOPATH: %s", dep.Path, tempGoPath)
-	goGetCmd := exec.Command("go", "get", "-u", "-d", dep.Path)
+	args := []string{"get", "-u", "-d", dep.Path}
+	if os.Getenv("GOMOD_OVERRIDE_ALLOW_INSECURE") != "" {
+		args = append(args[:2], append([]string{"-insecure"}, args[2:]...)...)
+	}
+
+	log.Printf("Running go %s in temporary GOPATH: %s", strings.Join(args, " "), tempGoPath)
+	goGetCmd := exec.Command("go", args...)
 
 	env := os.Environ()
 	for i, key := range env {


### PR DESCRIPTION
Unfortunately some module dependencies still refer to HTTP paths without TLS - `go get` does not allow that without the `-insecure` flag, so allow that to be set if necessary.