### PR TITLE
Use unmodified version for non-Git repositories

### DIFF
--- a/gomod-override/dependency.go
+++ b/gomod-override/dependency.go
@@ -40,6 +40,13 @@ func (dep dependency) ToGoPkgConstraint() (gopkgConstraint, error) {
 				var err error
 				sha, err = dep.resolveAbbreviatedSHA(sha)
 				if err != nil {
+					// This is likely not a Git repo, so just use the unmodified version
+					if err == git.ErrRepositoryNotExists {
+						return gopkgConstraint{
+							Name:    dep.Path,
+							Version: sha,
+						}, nil
+					}
 					return gopkgConstraint{}, errors.Wrapf(err, "error resolving abbreviated SHA for %q", dep.Path)
 				}
 			}


### PR DESCRIPTION
Serveral of our upstreams now have a dependency on a Bazaar repository. Since it's pinned to a specific revision, this looks like a short Git SHA which we try to resolve using `go get` before finding the complete SHA. If we can't open the repository resulting from `go get`, we should use the SHA component as is, since it likely refers to another VCS revision identifier.