### PR TITLE
Add gomod-doccopy tool

### DIFF
--- a/gomod-doccopy/README.md
+++ b/gomod-doccopy/README.md
@@ -1,0 +1,19 @@
+# `gomod-doccopy`
+
+Go modules can be used in a mode which populate a `vendor/` directory inside a
+repository in a `GOPATH`, preserving much of the workflow of tools such as
+`dep`. Unfortunately, it only copies Go files from packages needed to build.
+
+For bridged Terraform providers, we also need the `website/` directory present
+in order to create documentation.
+
+This tool recursively copies the `website/` directory from the machine module
+cache (which represents a complete version of the repository) to the
+appropriate spot in the `vendor` directory for a given Terraform provider.
+
+## Usage
+
+```
+gomod-doccopy -provider terraform-provider-xyz [-org not-terraform-providers] [-v]
+```
+

--- a/gomod-doccopy/main.go
+++ b/gomod-doccopy/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+var (
+	flags        = flag.NewFlagSet("gomod-doccopy", flag.ExitOnError)
+	providerOrg  = flags.String("org", "terraform-providers", "provider GitHub org")
+	providerName = flags.String("provider", "", "provider name")
+	verbose      = flags.Bool("v", false, "verbose output")
+)
+
+func main() {
+	flags.Parse(os.Args[1:])
+
+	if *providerName == "" {
+		fmt.Fprintf(os.Stderr, "missing required -provider flag value\n")
+		os.Exit(1)
+	}
+
+	// Ensure go.mod file exists and we're running from the project root,
+	// and that ./vendor/modules.txt file exists.
+	cwd, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "go.mod")); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "cannot find `go.mod` file\n")
+		os.Exit(1)
+	}
+	modtxtPath := filepath.Join(cwd, "vendor", "modules.txt")
+	if _, err := os.Stat(modtxtPath); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "cannot find vendor/modules.txt, first run `go mod vendor` and try again\n")
+		os.Exit(1)
+	}
+
+	targetProviderImportPath := fmt.Sprintf("github.com/%s/%s", *providerOrg, *providerName)
+	fmt.Println(targetProviderImportPath)
+
+	// Parse/process modules.txt file of pkgs
+	f, _ := os.Open(modtxtPath)
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if line[0] != 35 {
+			continue
+		}
+		s := strings.Split(line, " ")
+
+		if s[1] != targetProviderImportPath {
+			if *verbose == true {
+				log.Printf("Ignoring import path: %s", s[1])
+			}
+			continue
+		}
+
+		moduleDirectory := pkgModPath(s[1], s[2])
+		if *verbose == true {
+			log.Printf("Needs to copy from %s", moduleDirectory)
+		}
+
+		if _, err := os.Stat(moduleDirectory); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "module path %q does not exist, check $GOPATH/pkg/mod\n", moduleDirectory)
+			os.Exit(1)
+		}
+
+		src := filepath.Join(moduleDirectory, "website")
+		dest := filepath.Join("vendor", s[1], "website")
+
+		if err := copyDir(src, dest); err != nil {
+			fmt.Fprintf(os.Stderr, "error copying website/ directory: %s\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func pkgModPath(importPath, version string) string {
+	goPath := os.Getenv("GOPATH")
+	if goPath == "" {
+		// the default GOPATH for go v1.11
+		goPath = filepath.Join(os.Getenv("HOME"), "go")
+	}
+
+	var normPath string
+
+	for _, char := range importPath {
+		if unicode.IsUpper(char) {
+			normPath += "!" + string(unicode.ToLower(char))
+		} else {
+			normPath += string(char)
+		}
+	}
+
+	return filepath.Join(goPath, "pkg", "mod", fmt.Sprintf("%s@%s", normPath, version))
+}
+
+// Dir copies a whole directory recursively
+func copyDir(src string, dst string) error {
+	var err error
+	var fds []os.FileInfo
+
+	if err = os.MkdirAll(dst, 0744); err != nil {
+		return err
+	}
+
+	if fds, err = ioutil.ReadDir(src); err != nil {
+		return err
+	}
+	for _, fd := range fds {
+		srcfp := path.Join(src, fd.Name())
+		dstfp := path.Join(dst, fd.Name())
+
+		if fd.IsDir() {
+			if err = copyDir(srcfp, dstfp); err != nil {
+				return err
+			}
+		} else {
+			if err = copyFile(srcfp, dstfp); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// File copies a single file from src to dst
+func copyFile(src string, dst string) error {
+	var err error
+	var srcfd *os.File
+	var dstfd *os.File
+
+	if srcfd, err = os.Open(src); err != nil {
+		return err
+	}
+	defer srcfd.Close()
+
+	if dstfd, err = os.Create(dst); err != nil {
+		return err
+	}
+	defer dstfd.Close()
+
+	if _, err = io.Copy(dstfd, srcfd); err != nil {
+		return err
+	}
+	return os.Chmod(dst, 0644)
+}


### PR DESCRIPTION
Go modules can be used in a mode which populate a `vendor/` directory inside a repository in a `GOPATH`, preserving much of the workflow of tools such as `dep`. Unfortunately, it only copies Go files from packages needed to build.

For bridged Terraform providers, we also need the `website/` directory present in order to create documentation.

This tool recursively copies the `website/` directory from the machine module cache (which represents a complete version of the repository) to the appropriate spot in the `vendor` directory for a given Terraform provider.

_This is definitely not a pull request I am particularly proud of, but all of the advice I have seen is that this is the only way to use `go mod vendor` and have non-Go files copied in, and a tool specialised to our narrow usage pattern seems better than a more general one at this point._