### PR TITLE
Handle module replacement in gomod-doccopy

### DIFF
--- a/gomod-doccopy/README.md
+++ b/gomod-doccopy/README.md
@@ -11,13 +11,9 @@ This tool recursively copies the `website/` directory from the machine module
 cache (which represents a complete version of the repository) to the
 appropriate spot in the `vendor` directory for a given Terraform provider.
 
-If using a fork of a Terraform Provider and `replace` directive in `go.mod`, 
-specify `-src-org` as the replacement path, and if necessary, `-dest-org` as
-the original target.
-
 ## Usage
 
 ```
-gomod-doccopy -provider terraform-provider-xyz [-src-org not-terraform-providers] [-dest-org something-else] [-v]
+gomod-doccopy -provider terraform-provider-xyz [-org not-terraform-providers] [-v]
 ```
 

--- a/gomod-doccopy/main.go
+++ b/gomod-doccopy/main.go
@@ -21,6 +21,13 @@ var (
 	verbose      = flags.Bool("v", false, "verbose output")
 )
 
+type moduleType string
+
+const (
+	ModuleTypeRequired moduleType = "ModuleTypeRequired"
+	ModuleTypeReplaced moduleType = "ModuleTypeReplaced"
+)
+
 func main() {
 	flags.Parse(os.Args[1:])
 
@@ -63,6 +70,19 @@ func main() {
 		}
 		s := strings.Split(line, " ")
 
+		var modType moduleType
+		if len(s) == 3 {
+			modType = ModuleTypeRequired
+		} else if len(s) == 6 {
+			modType = ModuleTypeReplaced
+		} else {
+			fmt.Fprintf(os.Stderr, "unable to determine module type from module.txt line\n\t%s", line)
+			os.Exit(1)
+		}
+		if *verbose == true {
+			log.Printf("Module Type: %s", modType)
+		}
+
 		if s[1] != targetProviderImportPath {
 			if *verbose == true {
 				log.Printf("Ignoring import path: %s", s[1])
@@ -70,7 +90,14 @@ func main() {
 			continue
 		}
 
-		moduleDirectory := pkgModPath(s[1], s[2])
+		moduleDirectory := ""
+		switch modType {
+		case ModuleTypeRequired:
+			moduleDirectory = pkgModPath(s[1], s[2])
+		case ModuleTypeReplaced:
+			moduleDirectory = pkgModPath(s[4], s[5])
+		}
+
 		if *verbose == true {
 			log.Printf("Needs to copy from %s", moduleDirectory)
 		}

--- a/gomod-doccopy/main.go
+++ b/gomod-doccopy/main.go
@@ -15,11 +15,10 @@ import (
 )
 
 var (
-	flags             = flag.NewFlagSet("gomod-doccopy", flag.ExitOnError)
-	providerSourceOrg = flags.String("src-org", "terraform-providers", "source provider GitHub org")
-	providerDestOrg   = flags.String("dest-org", "terraform-providers", "source provider GitHub org")
-	providerName      = flags.String("provider", "", "provider name")
-	verbose           = flags.Bool("v", false, "verbose output")
+	flags        = flag.NewFlagSet("gomod-doccopy", flag.ExitOnError)
+	providerOrg  = flags.String("org", "terraform-providers", "provider GitHub org")
+	providerName = flags.String("provider", "", "provider name")
+	verbose      = flags.Bool("v", false, "verbose output")
 )
 
 func main() {
@@ -47,9 +46,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	targetProviderImportSourcePath := fmt.Sprintf("github.com/%s/%s", *providerSourceOrg, *providerName)
-	targetProviderImportDestPath := fmt.Sprintf("vendor/github.com/%s/%s", *providerDestOrg, *providerName)
-	fmt.Println(targetProviderImportSourcePath, " => ", targetProviderImportDestPath)
+	targetProviderImportPath := fmt.Sprintf("github.com/%s/%s", *providerOrg, *providerName)
+	fmt.Println(targetProviderImportPath)
 
 	// Parse/process modules.txt file of pkgs
 	f, _ := os.Open(modtxtPath)
@@ -65,7 +63,7 @@ func main() {
 		}
 		s := strings.Split(line, " ")
 
-		if s[1] != targetProviderImportSourcePath {
+		if s[1] != targetProviderImportPath {
 			if *verbose == true {
 				log.Printf("Ignoring import path: %s", s[1])
 			}
@@ -83,13 +81,14 @@ func main() {
 		}
 
 		src := moduleDirectory
+		dest := filepath.Join("vendor", s[1])
 
-		if err := os.RemoveAll(targetProviderImportDestPath); err != nil {
-			fmt.Fprintf(os.Stderr, "error removing the target directory %q: %s\n", targetProviderImportDestPath, err)
+		if err := os.RemoveAll(dest); err != nil {
+			fmt.Fprintf(os.Stderr, "error removing the target directory %q: %s\n", dest, err)
 			os.Exit(1)
 		}
 
-		if err := copyDir(src, targetProviderImportDestPath); err != nil {
+		if err := copyDir(src, dest); err != nil {
 			fmt.Fprintf(os.Stderr, "error copying provider directory: %s\n", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
This approach for handling replaced module is required less user input, and is more correct than the (reverted) approach taken previously - instead of specifying source and destination organizations, we read the entire replacement from the modules.txt file and use that where appropriate.

This is necessary for when we replace import paths with forks of providers (e.g. AWS, Azure).

In order to make progress elsewhere I'll merge this pending CI, and address any issues post-hoc.