### PR TITLE
Remove -o nounset from tfgen publishing script

### DIFF
--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -8,7 +8,10 @@
 # If using this to publish a hand-written package which happens to correspond to most of the
 # common tfgen layout, but does not have a python package, set NO_TFGEN_PYTHON_PACKAGE in the
 # environment to any non-empty value.
-set -o nounset -o errexit -o pipefail
+
+set -o errexit
+set -o pipefail
+
 if [ "$#" -ne 1 ]; then
     >&2 echo "usage: $0 <path-to-repository-root>"
     exit 1


### PR DESCRIPTION
Since we use the existence of NO_TFGEN_PYTHON_PACKAGE to indicate that we want to skip a Python provider, having option `nounset` on causes problems - according to ShellCheck we're ok here, so this commit removes that option from the script, fixing package builds for providers which do _not_ opt out of Python support.

Note that this is what is causing the build failure for GCP, currently.