### PR TITLE
Use Python 3 in our infrastructure scripts

### DIFF
--- a/ci/ensure-dependencies
+++ b/ci/ensure-dependencies
@@ -30,4 +30,4 @@ $(go env GOPATH)/src/github.com/pulumi/scripts/ci/check-worktree-is-clean.sh
 
 # Set stdout back to blocking to avoid problems writing large outputs.
 # https://github.com/pulumi/pulumi-ppc/issues/176
-python -c 'import fcntl, os, sys; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); print("stdout was " + ("nonblocking" if flags & os.O_NONBLOCK else "blocking")); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)'
+python3 -c 'import fcntl, os, sys; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); print("stdout was " + ("nonblocking" if flags & os.O_NONBLOCK else "blocking")); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)'

--- a/ci/show-elapsed-time
+++ b/ci/show-elapsed-time
@@ -1,10 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Pipe stdin to stdout, prepending each line with the seconds elapsed since
 # the start of the command.
-
-from __future__ import print_function
-
 from datetime import datetime
 import sys
 


### PR DESCRIPTION
Pulumi itself now requires Python 3 and Python 2.7 will be EOL
shortly.  Let's explicitly request `python3` and `pip3`.

Contributes To: #37