### PR TITLE
Don't fail when a package has already been published

### DIFF
--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -53,13 +53,32 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     # If the package doesn't have a pre-release tag, use the tag of latest instead of
     # dev. NPM uses this tag as the default version to add, so we want it to mean
     # the newest released version.
+    PKG_NAME=$(jq -r .name < package.json)
     PKG_VERSION=$(jq -r .version < package.json)
     if [[ "${PKG_VERSION}" != *-dev* ]] && [[ "${PKG_VERSION}" != *-alpha* ]]; then
         NPM_TAG="latest"
     fi
 
-    # Now, perform the publish.
-    npm publish -tag "${NPM_TAG}"
+    # Now, perform the publish. The logic here is a little goofy because npm provides
+    # no way to say "if the package already exists, don't fail" but we want these
+    # semantics (so, for example, we can restart builds which may have failed after
+    # publishing, or so two builds can run concurrently, which is the case for when we
+    # tag master right after pushing a new commit and the push and tag travis jobs both
+    # get the same version.
+    #
+    # We exploit the fact that `npm info <package-name>@<package-version>` has no output
+    # when the package does not exist.
+    if [ "$(npm info ${PKG_NAME}@${PKG_VERSION})" == "" ]; then
+        if ! npm publish -tag "${NPM_TAG}"; then
+	    # if we get here, we have a TOCTOU issue, so check again
+	    # to see if it published. If it didn't bail out.
+	    if [ "$(npm info ${PKG_NAME}@${PKG_VERSION})" == "" ]; then
+		echo "NPM publishing failed, aborting"
+		exit 1
+	    fi
+
+	fi
+    fi
     npm info 2>/dev/null
 
     # And finally restore the original package.json.
@@ -75,6 +94,7 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
         twine upload \
             -u pulumi -p "${PYPI_PASSWORD}" \
             "${SOURCE_ROOT}/sdk/python/bin/dist/*.tar.gz" \
+	    --skip-existing \
             --verbose
     fi
 fi


### PR DESCRIPTION
If the package we are trying to publish already exists, just continue
along our merry way. This happens for us in cases where we have a push
build for master racing with the tag build (when we tag HEAD of master
during a release) and can also happen if we need to restart a build.

NPM doesn't make it super easy to do this, so we throw a little bash
elbow grease at the problem. You might think that instead of looking
at the output of `npm info` we could instead look at the return code,
but sadly for us `npm info foo@some-version-that-doesnt-exist` does
not have a non zero exit code.