### PR TITLE
List pyenv versons before selecting one

### DIFF
--- a/ci/install-common-toolchain.sh
+++ b/ci/install-common-toolchain.sh
@@ -45,6 +45,7 @@ fi
 
     # On Linux Travis, System Python is 2.7.X, use `pyenv` to pick up Python 3.6.7
     if [ "${OS}" = "linux" ]; then
+        pyenv versions
         pyenv global 3.6.7
     fi
 


### PR DESCRIPTION
This is to aid debugging in `pulumi-vault` which seems to be claiming that Python 3.6.7 is not available in Travis anymore, but is useful generally and should not unduly delay builds