### PR TITLE
Use Node 10 by default

### DIFF
--- a/ci/install-common-toolchain.sh
+++ b/ci/install-common-toolchain.sh
@@ -1,4 +1,4 @@
-nvm install ${NODE_VERSION-v8.11.1}
+nvm install ${NODE_VERSION-v10.18.1}
 
 # Travis sources this script, so we can export variables into the
 # outer shell, so we don't want to set options like nounset because


### PR DESCRIPTION
Node 8 is EOL, and some dependencies no longer support it.

Part of pulumi/pulumi#3732.