### PR TITLE
Detect feature branches written with a different format

### DIFF
--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -43,11 +43,15 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
 
     NPM_TAG="dev"
 
-    # We use the "features/" prefix on branches that we want to build and publish for doing
-    # cross repo work. But in this case, we don't want to publish over "dev", since the bits
+    # We use the "features/" and "feature-" prefix on branches that we want to build and publish for
+    # doing cross repo work. But in this case, we don't want to publish over "dev", since the bits
     # could be totally busted and the dev tag tracks master.
     if [[ "${TRAVIS_BRANCH:-}" == features/* ]]; then
         NPM_TAG=$(echo "${TRAVIS_BRANCH}" | sed -e 's|^features/|feature-|g')
+    fi
+
+    if [[ "${TRAVIS_BRANCH:-}" == feature-* ]]; then
+        NPM_TAG=$(echo "${TRAVIS_BRANCH}")
     fi
 
     # If the package doesn't have a pre-release tag, use the tag of latest instead of


### PR DESCRIPTION
We currently detect `feature/XXX` branches, which we use to make npm tags like `feature-xxx`.  This works well except for one significant problem.

Specifically, because of https://github.com/golang/go/issues/30851 we are unable to reference these feature branches using go modules.  This is problematic as there's no easy way to then have downstream repos (like `@pulumi/aws`) reference the latest built version from this branch.  While we can reference teh package by commit, that's much more error prone and difficult to manage.

This PR simply allows us to actually write our branches like `feature-xxx` instead of just `features/xxx`.  This is actually simpler as we simply use that branch name as is instead of having to convert it to this form (like we do with `features/xxx`=>`feature-xxx`).

With this, downstream branches can then do `go get github.com/pulumi/pulumi@feature-2.0` and have it work properly.    

