### PR TITLE
Update .NET Core SDK to 3.1

### DIFF
--- a/ci/install-common-toolchain.sh
+++ b/ci/install-common-toolchain.sh
@@ -92,8 +92,8 @@ fi
         sudo apt-get update
         sudo apt-get install apt-transport-https
         sudo apt-get update
-        sudo apt-get install dotnet-sdk-3.0
-        sudo apt-get install aspnetcore-runtime-3.0
+        sudo apt-get install dotnet-sdk-3.1
+        sudo apt-get install aspnetcore-runtime-3.1
     else
         brew cask install dotnet-sdk
     fi


### PR DESCRIPTION
Start using .NET Core SDK 3.1. 3.0 is end of life within 1 month from now.
Steps described in https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-1804