### PR TITLE
Set `GO111MODULE=off` when getting ancillary tools

### DIFF
--- a/ci/install-common-toolchain.sh
+++ b/ci/install-common-toolchain.sh
@@ -63,7 +63,7 @@ fi
 
     # gocovmerge does not publish versioned releases, but it also hasn't been updated in two years, so
     # getting HEAD is pretty safe.
-    go get -v github.com/wadey/gocovmerge
+    GO111MODULE=off go get -v github.com/wadey/gocovmerge
 
     echo "installing pipenv ${PIPENV_VERSION}"
     pip3 install --user "pipenv==${PIPENV_VERSION}"
@@ -103,7 +103,7 @@ fi
 			tar -xvz -C "$(go env GOPATH)/bin"
 
     echo "installing gomod-doccopy"
-    go get -v github.com/pulumi/scripts/gomod-doccopy
+    GO111MODULE=off go get -v github.com/pulumi/scripts/gomod-doccopy
 )
 
 # If the sub shell failed, bail out now.


### PR DESCRIPTION
This commit prevents changes to `go.mod` resulting from installing tools via `go get` when in a module path outside of GOPATH, by explicitly disabling modules for these operations.

This addresses the type of failure seen in pulumi/pulumi-vault#29, and should not impact other types of job.