### PR TITLE
ignore pulumiManifest.go files in dirty check

### DIFF
--- a/ci/check-worktree-is-clean
+++ b/ci/check-worktree-is-clean
@@ -6,7 +6,7 @@ set -o nounset -o errexit -o pipefail
 # and this addresses that.
 git update-index -q --refresh
 
-if ! git diff-files --quiet; then
+if ! git diff-files --quiet -- . ':(exclude)**/pulumiManifest.go'; then
     >&2 echo "error: working tree is not clean, aborting!"
     git status
     git diff

--- a/ci/check-worktree-is-clean.sh
+++ b/ci/check-worktree-is-clean.sh
@@ -6,7 +6,7 @@ set -o nounset -o errexit -o pipefail
 # and this addresses that.
 git update-index -q --refresh
 
-if ! git diff-files --quiet; then
+if ! git diff-files --quiet -- . ':(exclude)**/pulumiManifest.go'; then
     >&2 echo "error: working tree is not clean, aborting!"
     git status
     git diff


### PR DESCRIPTION
This change ignores all changes in pulumiManifest.go files when doing the dirty check. This will allow us to check these files in instead of gitignoring them, which is currently breaking plugin acquisition for go. 

See https://github.com/pulumi/pulumi/issues/4118

with changes to pulumiManifest only:
```sh
Evans-MBP:pulumi-aws evanboyle$ git status
On branch master
Your branch is ahead of 'origin/master' by 2 commits.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   sdk/go/aws/pulumiManifest.go

no changes added to commit (use "git add" and/or "git commit -a")
Evans-MBP:pulumi-aws evanboyle$ ~/go/src/github.com/pulumi/scripts/ci/check-worktree-is-clean.sh
Evans-MBP:pulumi-aws evanboyle$ 

```

with changes to pulumiManifest + another file:
```sh
Evans-MBP:pulumi-aws evanboyle$ git status
On branch master
Your branch is ahead of 'origin/master' by 2 commits.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   provider/go.sum
	modified:   sdk/go/aws/pulumiManifest.go

no changes added to commit (use "git add" and/or "git commit -a")
Evans-MBP:pulumi-aws evanboyle$ ~/go/src/github.com/pulumi/scripts/ci/check-worktree-is-clean.sh
error: working tree is not clean, aborting!
On branch master
Your branch is ahead of 'origin/master' by 2 commits.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   provider/go.sum
	modified:   sdk/go/aws/pulumiManifest.go

no changes added to commit (use "git add" and/or "git commit -a")
diff --git a/provider/go.sum b/provider/go.sum
index f2cd18c80..ef067aab8 100644
--- a/provider/go.sum
+++ b/provider/go.sum
@@ -688,6 +688,7 @@ github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pulumi/pulumi-aws v1.27.0 h1:YhkYCB1q69BxebUS408jatUOnUpNW+wnwPhfAUxF5wM=
 github.com/pulumi/pulumi-terraform-bridge v1.8.4-0.20200326020012-c5fd7318ced1 h1:8kQVP38y6kgvy21uT5G9vMp/MYKo3uZKvxSoUtCetJQ=
 github.com/pulumi/pulumi-terraform-bridge v1.8.4-0.20200326020012-c5fd7318ced1/go.mod h1:EGMJtAh9rdqiqO0B5P458iigWu7BAwLxqgUWvGs33Es=
 github.com/pulumi/pulumi/pkg v0.0.0-20200325225746-80f1989600a3 h1:CUswHMz3r5GBJHeGL5p4NtAGwqoelFyv54KW1A1XQfk=
diff --git a/sdk/go/aws/pulumiManifest.go b/sdk/go/aws/pulumiManifest.go
index cbb620ea9..9665ff178 100644
--- a/sdk/go/aws/pulumiManifest.go
+++ b/sdk/go/aws/pulumiManifest.go
@@ -6,7 +6,7 @@ package aws
 
 import (
        "github.com/pulumi/pulumi/sdk/go/pulumi"
-)
+)sdfsd
 
 func init() {
        pulumi.RegisterPackage(pulumi.PackageInfo{Name: "aws", Version: "1.28.0-alpha.1585231092+ga38c5bc31f"})

```