### PR TITLE
Call gen_resource_docs.sh when building package

### DIFF
--- a/ci/build-package-docs.sh
+++ b/ci/build-package-docs.sh
@@ -55,6 +55,9 @@ go get -u github.com/pkg/errors
 # Regenerate the Node.JS SDK docs
 PKGS=${PKG_NAME} NOBUILD=true ./scripts/run_typedoc.sh
 
+# Regenerate the resource docs
+./scripts/gen_resource_docs.sh ${PKG_NAME}
+
 # Regenerate the Python docs
 ./scripts/generate_python_docs.sh
 

--- a/ci/build-package-docs.sh
+++ b/ci/build-package-docs.sh
@@ -64,7 +64,7 @@ case ${PKG_NAME} in
     "pulumi" | "policy")
         echo "Skipping gen_resource_docs step because package doesn't contain any resources."
         ;;
-    "awsx" | "eks" | "kubernetesx")
+    "aiven" | "awsx" | "eks" | "kubernetesx" | "mailgun")
         # gen_resource_docs.sh assumes the package has a `make generate_schema` step.
         echo "Skipping gen_resource_docs step because package hasn't been schematized yet."
         ;;

--- a/ci/build-package-docs.sh
+++ b/ci/build-package-docs.sh
@@ -55,8 +55,8 @@ go get -u github.com/pkg/errors
 # Regenerate the Node.JS SDK docs
 PKGS=${PKG_NAME} NOBUILD=true ./scripts/run_typedoc.sh
 
-# Regenerate the resource docs
-./scripts/gen_resource_docs.sh ${PKG_NAME}
+# Regenerate the resource docs (for the specific plugin version)
+./scripts/gen_resource_docs.sh ${PKG_NAME} true ${VERSION}
 
 # Regenerate the Python docs
 ./scripts/generate_python_docs.sh

--- a/ci/build-package-docs.sh
+++ b/ci/build-package-docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# build-package-docs.sh updates the docs generated from the indicated repo
+# build-package-docs.sh updates the docs generated from the indicated repo.
 #
 # Note that if PULUMI_BOT_GITHUB_API_TOKEN is unset, this script will fail. If this happens, the doc build can be run
 # manually by triggering a job using the following steps:
@@ -29,7 +29,7 @@ if [[ -z "${PULUMI_BOT_GITHUB_API_TOKEN:-}" ]]; then
 fi
 
 if [[ -z "${1:-}" ]]; then
-    echo "usage $0 <package-simple-name>"
+    echo "Usage: $0 <package-simple-name>"
     exit 1
 fi
 
@@ -43,10 +43,14 @@ VERSION=${TRAVIS_TAG#"v"}
 
 echo "Building SDK docs for version ${VERSION}:"
 
-# Clone the docs repo and fetch its dependencies.
+# Clone the docs repo and fetch its dependencies, since the bits necessary for
+# generating documentation are found there. (Specifically docs/tools/resourcedocsgen; which
+# has some overrides in the go.mod file that expect code from pulumi/pulumi to be local.)
+git clone "https://github.com/pulumi/pulumi.git" "$(go env GOPATH)/src/github.com/pulumi/pulumi"
 git clone "https://github.com/pulumi/docs.git" "$(go env GOPATH)/src/github.com/pulumi/docs"
+
 cd "$(go env GOPATH)/src/github.com/pulumi/docs"
-make ensure
+make ensure ensure_tools
 
 go get -u github.com/cbroglie/mustache
 go get -u github.com/gobuffalo/packr
@@ -55,8 +59,19 @@ go get -u github.com/pkg/errors
 # Regenerate the Node.JS SDK docs
 PKGS=${PKG_NAME} NOBUILD=true ./scripts/run_typedoc.sh
 
-# Regenerate the resource docs (for the specific plugin version)
-./scripts/gen_resource_docs.sh ${PKG_NAME} true ${VERSION}
+# Regenerate the resource docs (for the specific plugin version) if applicable.
+case ${PKG_NAME} in
+    "pulumi" | "policy")
+        echo "Skipping gen_resource_docs step because package doesn't contain any resources."
+        ;;
+    "awsx" | "eks" | "kubernetesx")
+        # gen_resource_docs.sh assumes the package has a `make generate_schema` step.
+        echo "Skipping gen_resource_docs step because package hasn't been schematized yet."
+        ;;
+    *)
+        ./scripts/gen_resource_docs.sh ${PKG_NAME} true ${VERSION}
+        ;;
+esac
 
 # Regenerate the Python docs
 ./scripts/generate_python_docs.sh


### PR DESCRIPTION
I have no idea what I'm talking about, so please double check my work here.

----

We want to build the resource docs (`gen_resource_docs.sh` in the `docs` repo) as part of running `ci/build-package-docs.sh`. @praneetloke actually did the work to parameterize this file in https://github.com/pulumi/docs/pull/2820:

> I also updated the gen_resource_docs.sh script to accept a provider name override to generate docs for a single provider, which is required for CI scenarios when we release a new provider. [This commit](https://github.com/pulumi/docs/pull/2820/commits/24037853eebd8518e5f3dde626b2a257a94f4251) has those changes. We are not yet ready to make the upstream script changes to make use of this (though I expect it to work). My main motivation for doing this is for my local development reasons.

See: https://github.com/pulumi/docs/blob/master/scripts/gen_resource_docs.sh#L8

Testing things locally, it looks like things worked as expected.

I cloned the `pulumi/pulumi-kafka` repo, ran `make ensure build install`. And then ran:

```zsh
$(go env GOPATH)/src/github.com/pulumi/scripts/ci/build-package-docs.sh kafka
```

After skipping failures due to missing environment variables, it the status of the `pulumi/docs` repo that was cloned as part of the script appeared to have just generated the resources for the `pulumi/pulumi-kafka` package. (This is what we want, right? Just to have generated updates for the docs for the `kafka` package, and not _everything_?)

```zsh
[ 2:37PM] √ ~/go/src/github.com/pulumi/docs % git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   content/docs/reference/pkg/kafka/topic.md
        modified:   content/docs/reference/pkg/nodejs/pulumi/kafka/_index.md
        modified:   content/docs/reference/pkg/nodejs/pulumi/kafka/config/_index.md

no changes added to commit (use "git add" and/or "git commit -a")
[ 2:37PM] √ ~/go/src/github.com/pulumi/docs % git diff --stat
 content/docs/reference/pkg/kafka/topic.md                       | 160 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---------------------------------------------------------------------
 content/docs/reference/pkg/nodejs/pulumi/kafka/_index.md        |   2 +-
 content/docs/reference/pkg/nodejs/pulumi/kafka/config/_index.md |   2 +-
 3 files changed, 82 insertions(+), 82 deletions(-)
```

Update:

[Praneet mentioned](https://github.com/pulumi/scripts/issues/104#issuecomment-612229758) that the `gen_resource_docs.sh` script accepts a couple of other parameters too, to fetch a specific version of the plugin to download/install and generate docs for. So we wire that through, rather than using the default behavior to get the latest released package.

So 🤞 everything should "just work" now? #WCGW

Fixes #104 