### PR TITLE
Remove GO GET for specific version of Pulumi

### DIFF
--- a/ci/run-at-head
+++ b/ci/run-at-head
@@ -113,8 +113,6 @@ if [ "${SPECIFIC_VERSION}" != "" ]; then
     done
 
     export PULUMI_TEST_NODE_OVERRIDES="${NODE_OVERRIDES:1}"
-
-    pushd misc/test && GO111MODULE=on go get "github.com/pulumi/pulumi@${SPECIFIC_VERSION}" && popd
 fi
 
 make "travis_${TRAVIS_EVENT_TYPE}"


### PR DESCRIPTION
We are going to default the testing framework to the beta Pulumi
packages. Nothing in the framework was changed, therefore we don't
even need to do this, the standard `make ensure` will install the
correct go mod

This means we won't ever get into this weird situation of trying to
install a module that isn't a v2 when it should be

This has also been broken since we upgraded to go modules in the
Pulumi repo as we now have SDK and PKG rather than just pulumi as
a whole