### PR TITLE
Remove aiven and mailgun from list of excluded repos for generating resource docs

### DIFF
--- a/ci/build-package-docs.sh
+++ b/ci/build-package-docs.sh
@@ -64,7 +64,7 @@ case ${PKG_NAME} in
     "pulumi" | "policy")
         echo "Skipping gen_resource_docs step because package doesn't contain any resources."
         ;;
-    "aiven" | "awsx" | "eks" | "kubernetesx" | "mailgun")
+    "awsx" | "eks" | "kubernetesx")
         # gen_resource_docs.sh assumes the package has a `make generate_schema` step.
         echo "Skipping gen_resource_docs step because package hasn't been schematized yet."
         ;;


### PR DESCRIPTION
Related to https://github.com/pulumi/docs/issues/2785.

Now that we have added the `generate_schema` `Makefile` target for both `aiven` and `mailgun`, we can generate resource docs for those as well.