### PR TITLE
Pass the package name when generating Python docs.

### DIFF
--- a/ci/build-package-docs.sh
+++ b/ci/build-package-docs.sh
@@ -74,7 +74,7 @@ case ${PKG_NAME} in
 esac
 
 # Regenerate the Python docs
-./scripts/generate_python_docs.sh
+./scripts/generate_python_docs.sh "${PKG_NAME}"
 
 if [[ "${PKG_NAME}" == "pulumi" ]]; then
     # Regenerate the CLI docs


### PR DESCRIPTION
Fixes #111.

Now that the `generate_python_docs.sh` script supports passing the package name to generate docs for, we can make use of that when making provider releases.