### PR TITLE
Clone `pulumi/pulumi` only if the directory doesn't exist

### DIFF
--- a/ci/build-package-docs.sh
+++ b/ci/build-package-docs.sh
@@ -46,7 +46,9 @@ echo "Building SDK docs for version ${VERSION}:"
 # Clone the docs repo and fetch its dependencies, since the bits necessary for
 # generating documentation are found there. (Specifically docs/tools/resourcedocsgen; which
 # has some overrides in the go.mod file that expect code from pulumi/pulumi to be local.)
-git clone "https://github.com/pulumi/pulumi.git" "$(go env GOPATH)/src/github.com/pulumi/pulumi"
+if [[ ! -d "$(go env GOPATH)/src/github.com/pulumi/pulumi" ]]; then
+    git clone "https://github.com/pulumi/pulumi.git" "$(go env GOPATH)/src/github.com/pulumi/pulumi"
+fi
 git clone "https://github.com/pulumi/docs.git" "$(go env GOPATH)/src/github.com/pulumi/docs"
 
 cd "$(go env GOPATH)/src/github.com/pulumi/docs"


### PR DESCRIPTION
The last time I tagged a release in the `pulumi/pulumi-policy` repo, after publishing the packages, when attempting to open the docs PR, the build failed with:

```
$(go env GOPATH)/src/github.com/pulumi/scripts/ci/build-package-docs.sh policy
Building SDK docs for version 1.1.0:
fatal: destination path '/home/travis/gopath/src/github.com/pulumi/pulumi' already exists and is not an empty directory.
Makefile:12: recipe for target 'publish_packages' failed
make: *** [publish_packages] Error 128
```

The problem is this script is now trying to clone `pulumi/pulumi`, but in the case of the `pulumi-policy` repo, the `pulumi/pulumi` repo directory already exists, so the git clone fails.

As far as I can tell, the `pulumi/pulumi-policy` repo doesn't explicitly clone the `pulumi/pulumi` repo, but it does have [this line](https://github.com/pulumi/pulumi-policy/blob/bec644e4f484ac8cf4770be86f77584bede0e81a/Makefile#L8
) in its `Makefile`:

```makefile
ensure::
	# Golang dependencies for the integration tests.
	go get -t -d ./tests/integration
```

The policy integration tests make use of `github.com/pulumi/pulumi/sdk/go/common/testing`, so presumably the `go get` is pulling down `pulumi/pulumi` repo.

To workaround, only clone the `pulumi/pulumi` repo if the directory in GOPATH doesn't already exist.

Fixes https://github.com/pulumi/pulumi-policy/issues/238