### PR TITLE
Set AWS_SESSION_TOKEN instead of AWS_SECURITY_TOKEN in configure-aws.sh

### DIFF
--- a/ci/configure-aws.sh
+++ b/ci/configure-aws.sh
@@ -48,7 +48,7 @@ function assume_iam_role() {
 
     export AWS_ACCESS_KEY_ID=$(echo ${CREDS_JSON}     | jq ".Credentials.AccessKeyId" --raw-output)
     export AWS_SECRET_ACCESS_KEY=$(echo ${CREDS_JSON} | jq ".Credentials.SecretAccessKey" --raw-output)
-    export AWS_SECURITY_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
+    export AWS_SESSION_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
 }
 
 # Clear the environment variables set after calling assume_iam_role to get back to


### PR DESCRIPTION
`AWS_SECURITY_TOKEN` is not an env var that is used by the AWS SDK. This should instead be `AWS_SESSION_TOKEN`, which coincides with the property name used in the output of `aws sts assume-role` called `SessionToken`.