### PR TITLE
Use xargs for publishing nuget packages

### DIFF
--- a/ci/add-plugin-installer-script.js
+++ b/ci/add-plugin-installer-script.js
@@ -37,7 +37,7 @@ stdin.on("close", function() {
     if (name.lastIndexOf("/") !== -1) {
         name = name.substring(name.lastIndexOf("/")+1);
     }
-    packageJSON.scripts["install"] = `node scripts/install-pulumi-plugin.js resource ${name} ${packageJSON.version}`;
+    packageJSON.scripts["install"] = `node scripts/install-pulumi-plugin.js resource ${name} --server ${packageJSON.repository}/releases/download/${packageJSON.version} ${packageJSON.version}`;
 
     // Now print out the result to stdout.
     console.log(JSON.stringify(packageJSON, null, 4));

--- a/ci/add-plugin-installer-script.js
+++ b/ci/add-plugin-installer-script.js
@@ -37,7 +37,7 @@ stdin.on("close", function() {
     if (name.lastIndexOf("/") !== -1) {
         name = name.substring(name.lastIndexOf("/")+1);
     }
-    packageJSON.scripts["install"] = `node scripts/install-pulumi-plugin.js resource ${name} --server ${packageJSON.repository}/releases/download/${packageJSON.version} ${packageJSON.version}`;
+    packageJSON.scripts["install"] = `node scripts/install-pulumi-plugin.js resource ${name} ${packageJSON.version}`;
 
     // Now print out the result to stdout.
     console.log(JSON.stringify(packageJSON, null, 4));

--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -121,7 +121,7 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
 
     # Finally, publish the NuGet package if any exists.
     if [ -n "${NUGET_PUBLISH_KEY}" ]; then
-        find "${SOURCE_ROOT}/sdk/dotnet/bin/Debug/" -name 'Pulumi.*.nupkg' \
-            -exec dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json {} ';'
+        find "${SOURCE_ROOT}/sdk/dotnet/bin/Debug/" -name 'Pulumi.*.nupkg' | \
+            xargs dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json
     fi
 fi

--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -94,9 +94,9 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     if [ -n "${NO_TFGEN_PYTHON_PACKAGE}" ] ; then
         echo "Skipping publishing pip package because of NO_TFGEN_PYTHON_PACKAGE"
     else
-        echo "Publishing Pip package to pulumi.com:"
+        echo "Publishing Pip package to pypi:"
         twine upload \
-            -u pulumi -p "${PYPI_PASSWORD}" \
+            -u "${PYPI_USERNAME}" -p "${PYPI_PASSWORD}" \
             "${SOURCE_ROOT}/sdk/python/bin/dist/*.tar.gz" \
 	    --skip-existing \
             --verbose

--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -11,6 +11,7 @@
 
 set -o errexit
 set -o pipefail
+set -o nounset
 
 if [ "$#" -ne 1 ]; then
     >&2 echo "usage: $0 <path-to-repository-root>"

--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -11,10 +11,29 @@
 
 set -o errexit
 set -o pipefail
-set -o nounset
 
 if [ "$#" -ne 1 ]; then
     >&2 echo "usage: $0 <path-to-repository-root>"
+    exit 1
+fi
+
+if [[ -z "$PYPI_USERNAME" ]]; then
+    echo "Must provide PYPI_USERNAME" 1>&2
+    exit 1
+fi
+
+if [[ -z "$PYPI_PASSWORD" ]]; then
+    echo "Must provide PYPI_PASSWORD" 1>&2
+    exit 1
+fi
+
+if [[ -z "$NUGET_PUBLISH_KEY" ]]; then
+    echo "Must provide NUGET_PUBLISH_KEY" 1>&2
+    exit 1
+fi
+
+if [[ -z "$NPM_TOKEN" ]]; then
+    echo "Must provide NPM_TOKEN" 1>&2
     exit 1
 fi
 
@@ -43,17 +62,6 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     mv package.json.publish package.json
 
     NPM_TAG="dev"
-
-    # We use the "features/" and "feature-" prefix on branches that we want to build and publish for
-    # doing cross repo work. But in this case, we don't want to publish over "dev", since the bits
-    # could be totally busted and the dev tag tracks master.
-    if [[ "${TRAVIS_BRANCH:-}" == features/* ]]; then
-        NPM_TAG=$(echo "${TRAVIS_BRANCH}" | sed -e 's|^features/|feature-|g')
-    fi
-
-    if [[ "${TRAVIS_BRANCH:-}" == feature-* ]]; then
-        NPM_TAG=$(echo "${TRAVIS_BRANCH}")
-    fi
 
     # If the package doesn't have a pre-release tag, use the tag of latest instead of
     # dev. NPM uses this tag as the default version to add, so we want it to mean
@@ -91,17 +99,12 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     mv package.json.dev package.json
     popd
 
-    # Next, publish the PyPI package, if we didn't opt out
-    if [ -n "${NO_TFGEN_PYTHON_PACKAGE}" ] ; then
-        echo "Skipping publishing pip package because of NO_TFGEN_PYTHON_PACKAGE"
-    else
-        echo "Publishing Pip package to pypi:"
-        twine upload \
-            -u "${PYPI_USERNAME}" -p "${PYPI_PASSWORD}" \
-            "${SOURCE_ROOT}/sdk/python/bin/dist/*.tar.gz" \
+    echo "Publishing Pip package to pypi:"
+    twine upload \
+        -u "${PYPI_USERNAME}" -p "${PYPI_PASSWORD}" \
+        "${SOURCE_ROOT}/sdk/python/bin/dist/*.tar.gz" \
 	    --skip-existing \
-            --verbose
-    fi
+        --verbose
 
     # Finally, publish the NuGet package if any exists.
     if [ -n "${NUGET_PUBLISH_KEY}" ]; then


### PR DESCRIPTION
Currently we use `find` for publishing nuget packages. `find` will only exit with a non 0 error code if you fail to traverse a directory.

This can lead to a situation whereby the nuget package fails to publish, but we never know about it:

```
find sdk/dotnet/bin/Debug -name 'Pulumi.*.nupkg' | xargs dotnet nuget push -k foobar -s https://api.nuget.org/v3/index.json
echo $?
0
```

With the addition of the fact that nuget keys expire, we probably need to be notified when nuget publishing fails.

This switches us to use xargs instead