### PR TITLE
Allow opting into sending wheels to PyPI

### DIFF
--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -42,7 +42,7 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     mv package.json.publish package.json
 
     NPM_TAG="dev"
-    
+
     ## We need split the GITHUB_REF into the correct parts
     ## so that we can test for NPM Tags
     IFS='/' read -ra my_array <<< "${GITHUB_REF:-}"
@@ -110,6 +110,22 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     # Next, publish the PyPI package, if we didn't opt out
     if [ -n "${NO_TFGEN_PYTHON_PACKAGE}" ] ; then
         echo "Skipping publishing pip package because of NO_TFGEN_PYTHON_PACKAGE"
+    elif [[ "${PYPI_PUBLISH_ARTIFACTS:-}" == "all" ]]; then
+        echo "Publishing Pip package to pypi as ${PYPI_PUBLISH_USERNAME}:"
+        echo "Distributions:"
+        ls ${SOURCE_ROOT}/sdk/python/bin/dist/*
+        twine upload \
+            -u "${PYPI_PUBLISH_USERNAME}" -p "${PYPI_PASSWORD}" \
+            "${SOURCE_ROOT}/sdk/python/bin/dist/*" \
+	    --skip-existing \
+            --verbose
+    elif [[ "${PYPI_PUBLISH_ARTIFACTS:-}" == "wheel" ]]; then
+        echo "Publishing Pip wheel package to pypi as ${PYPI_PUBLISH_USERNAME}:"
+        twine upload \
+            -u "${PYPI_PUBLISH_USERNAME}" -p "${PYPI_PASSWORD}" \
+            "${SOURCE_ROOT}/sdk/python/bin/dist/*.whl" \
+	    --skip-existing \
+            --verbose
     else
         echo "Publishing Pip package to pypi as ${PYPI_PUBLISH_USERNAME}:"
         twine upload \

--- a/ci/publish-tfgen-package
+++ b/ci/publish-tfgen-package
@@ -107,9 +107,30 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
         PYPI_PUBLISH_USERNAME="pulumi"
     fi
 
-    # Next, publish the PyPI package, if we didn't opt out
+    # Next, publish the PyPI package, if we didn't opt out.
+    #
+    # The precondition is that ${SOURCE_ROOT}/sdk/python/bin/dist/ contains one or more prebuilt files:
+    #
+    #     - source distribution, such as pulumi_kubernetes-4.2.0.tar.gz
+    #     - wheel distribution, such as pulumi_kubernetes-4.2.0-py3-none-any.whl
+    #
+    # There are various ways to produce these distirbutions from source. One of the simplest one is:
+    #
+    #     python -m build .
+    #
+    # See also:
+    #
+    #     - https://twine.readthedocs.io/en/stable/ for details on how `twine upload` works.
+    #     - https://pypa-build.readthedocs.io/en/latest/ docs on the build module
     if [ -n "${NO_TFGEN_PYTHON_PACKAGE}" ] ; then
         echo "Skipping publishing pip package because of NO_TFGEN_PYTHON_PACKAGE"
+    # Projects that set PYPI_PUBLISH_ARTIFACTS=all will publish both source and wheel distirbutions
+    # (dist/*) if built; this is currently preferred for Pulumi as we want the users to get wheel
+    # distributions by default but still support users that perform source-only installs as in:
+    #
+    #     pip install --no-binary :all: pulumi-kubernetes==4.1.0
+    #
+    # This behavior is gated by a flag until all Pulumi repositories get compatible.
     elif [[ "${PYPI_PUBLISH_ARTIFACTS:-}" == "all" ]]; then
         echo "Publishing Pip package to pypi as ${PYPI_PUBLISH_USERNAME}:"
         echo "Distributions:"
@@ -119,6 +140,8 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
             "${SOURCE_ROOT}/sdk/python/bin/dist/*" \
 	    --skip-existing \
             --verbose
+    # Projects that set PYPI_PUBLISH_ARTIFACTS=wheel will only publish the wheel distribution. This
+    # is currently not recommended.
     elif [[ "${PYPI_PUBLISH_ARTIFACTS:-}" == "wheel" ]]; then
         echo "Publishing Pip wheel package to pypi as ${PYPI_PUBLISH_USERNAME}:"
         twine upload \
@@ -126,6 +149,8 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
             "${SOURCE_ROOT}/sdk/python/bin/dist/*.whl" \
 	    --skip-existing \
             --verbose
+    # By default projects will only publish the source distribution. This maintains legacy behavior.
+    # Once all projects migrate to PYPI_PUBLISH_ARTIFACTS=all this may be made irrelevant.
     else
         echo "Publishing Pip package to pypi as ${PYPI_PUBLISH_USERNAME}:"
         twine upload \


### PR DESCRIPTION
With work like https://github.com/pulumi/pulumi-kubernetes/pull/2501 once a project is building wheels from a Pyproject.toml it might make sense to also send them to PyPI using twine. Adding some opt-in configurations here to send wheels, or both wheels and tar.gz.