### PR TITLE
Make check-worktree-is-clean consider non-staged new files as well

### DIFF
--- a/ci/check-worktree-is-clean
+++ b/ci/check-worktree-is-clean
@@ -6,7 +6,8 @@ set -o nounset -o errexit -o pipefail
 # and this addresses that.
 git update-index -q --refresh
 
-if ! git diff-files --quiet; then
+p=$(git status --porcelain)
+if [ -n "$p" ]; then
     >&2 echo "error: working tree is not clean, aborting!"
     git status
     git diff


### PR DESCRIPTION
The previous implementation would correctly alert for
- existing files with uncommitted changes, and
- net-new files in the index (i.e., staged via `git add`).

But it would not alert for net-new files that were not staged. The new implementation does.

It should be rather future-proof since it uses the `--porcelain` flag that meant for scripting.